### PR TITLE
Bump v0.1.10 policy version.

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,29 +4,29 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.9
+version: 0.1.10
 name: volumes-psp
 displayName: Volumes PSP
-createdAt: 2023-03-24T16:48:46.565703502Z
+createdAt: 2023-07-10T16:00:24.402878805Z
 description: Pod Security Policy that controls usage of volumes
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/volumes-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/volumes-psp:v0.1.9
+  image: ghcr.io/kubewarden/policies/volumes-psp:v0.1.10
 keywords:
 - psp
 - pod
 - volumes
 links:
 - name: policy
-  url: https://github.com/kubewarden/volumes-psp-policy/releases/download/v0.1.9/policy.wasm
+  url: https://github.com/kubewarden/volumes-psp-policy/releases/download/v0.1.10/policy.wasm
 - name: source
   url: https://github.com/kubewarden/volumes-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/volumes-psp:v0.1.9
+  kwctl pull ghcr.io/kubewarden/policies/volumes-psp:v0.1.10
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.10 policy version.        

Updates files bumping the policy version to v0.1.10

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
