### PR TITLE
feat: add option to ignore initContainers volumes in validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ to allow all kind of volumes.
 No other value can be specified together with `*`. For example,
 `allowedTypes: ['*', 'configMap']` is not a valid configuration setting.
 
+The policy also takes an optional `ignoreInitContainersVolumes` setting. This setting defaults to `false`.
+When set to `true`, volumes that are exclusively used by `initContainers` (and not by regular `containers`) are ignored during the validation process.
+

--- a/settings.go
+++ b/settings.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Settings struct {
-	AllowedTypes mapset.Set[string] `json:"allowedTypes"`
+	AllowedTypes                mapset.Set[string] `json:"allowedTypes"`
+	IgnoreInitContainersVolumes bool               `json:"ignoreInitContainersVolumes,omitempty"`
 }
 
 // Builds a new Settings instance starting from a validation
@@ -75,7 +76,8 @@ func (s *Settings) UnmarshalJSON(data []byte) error {
 	// This is needed becaus golang-set v2.3.0 has a bug that prevents
 	// the correct unmarshalling of ThreadUnsafeSet types.
 	rawSettings := struct {
-		AllowedTypes []string `json:"allowedTypes"`
+		AllowedTypes                []string `json:"allowedTypes"`
+		IgnoreInitContainersVolumes bool     `json:"ignoreInitContainersVolumes,omitempty"`
 	}{}
 
 	err := json.Unmarshal(data, &rawSettings)
@@ -84,6 +86,7 @@ func (s *Settings) UnmarshalJSON(data []byte) error {
 	}
 
 	s.AllowedTypes = mapset.NewThreadUnsafeSet[string](rawSettings.AllowedTypes...)
+	s.IgnoreInitContainersVolumes = rawSettings.IgnoreInitContainersVolumes
 
 	return nil
 }

--- a/settings.sample.json
+++ b/settings.sample.json
@@ -6,5 +6,6 @@
       "persistentVolumeClaim",
       "secret",
       "projected"
-   ]
+   ],
+   "ignoreInitContainersVolumes": true
 }

--- a/settings_test.go
+++ b/settings_test.go
@@ -99,3 +99,50 @@ func TestEmptySettingsAreValid(t *testing.T) {
 		t.Errorf("Settings are reported as not valid")
 	}
 }
+
+func TestParsingSettingsWithIgnoreInitContainersVolumes(t *testing.T) {
+	request := `
+	{
+		"request": "doesn't matter here",
+		"settings": {
+			"allowedTypes": ["configMap"],
+			"ignoreInitContainersVolumes": true
+		}
+	}
+	`
+	rawRequest := []byte(request)
+
+	settings, err := NewSettingsFromValidationReq(rawRequest)
+	if err != nil {
+		t.Errorf("Unexpected error %+v", err)
+	}
+
+	if !settings.IgnoreInitContainersVolumes {
+		t.Errorf("Expected IgnoreInitContainersVolumes to be true")
+	}
+
+	if !settings.AllowedTypes.Contains("configMap") {
+		t.Errorf("Missing allowedTypes value")
+	}
+}
+
+func TestParsingSettingsWithIgnoreInitContainersVolumesDefault(t *testing.T) {
+	request := `
+	{
+		"request": "doesn't matter here",
+		"settings": {
+			"allowedTypes": ["configMap"]
+		}
+	}
+	`
+	rawRequest := []byte(request)
+
+	settings, err := NewSettingsFromValidationReq(rawRequest)
+	if err != nil {
+		t.Errorf("Unexpected error %+v", err)
+	}
+
+	if settings.IgnoreInitContainersVolumes {
+		t.Errorf("Expected IgnoreInitContainersVolumes to be false by default")
+	}
+}

--- a/validate.go
+++ b/validate.go
@@ -71,11 +71,12 @@ func validate(payload []byte) ([]byte, error) {
 		})
 
 		if settings.IgnoreInitContainersVolumes {
-			// Skip volumes that are only used by initContainers and not by containers
-			if _, found := initContainerVolumeNames[volumeName]; found {
-				if _, usedByContainer := containerVolumeNames[volumeName]; !usedByContainer {
-					continue
-				}
+			_, usedByInitContainer := initContainerVolumeNames[volumeName]
+			_, usedByContainer := containerVolumeNames[volumeName]
+
+			if usedByInitContainer && !usedByContainer {
+				// Skip volumes that are only used by initContainers and not by containers
+				continue
 			}
 		}
 

--- a/validate.go
+++ b/validate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	onelog "github.com/francoispqt/onelog"
@@ -97,7 +98,7 @@ func validate(payload []byte) ([]byte, error) {
 			errMsg := fmt.Sprintf("volume '%s' of type '%s' is not in the AllowedTypes list",
 				volumeName, volumeType)
 			if err == nil {
-				err = fmt.Errorf("%s", errMsg)
+				err = errors.New(errMsg)
 			} else {
 				err = fmt.Errorf("%w; %s", err, errMsg)
 			}


### PR DESCRIPTION
## Description

Adds a new policy setting: ignoreInitContainersVolumes.
When enabled, volumes that are only used by initContainers (and not by main containers) are ignored during validation.
<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #82 
<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- Documentation -->
Test
To test this pull request, you can run the following commands:
Apply to Makefile
bats
Unit tests and e2e tests have been updated to cover the new setting and its edge cases.
You can also manually test with:
Apply to Makefile
'
Additional Information
Tradeoff
The new setting is optional and defaults to false, so it does not affect existing users.
Only minimal code changes were made to maximize backward compatibility and ease of review.
Potential improvement
Future: Support for skipping validation for volumes used by other container types (e.g., ephemeralContainers) if needed.
More granular control (e.g., per-volume or per-container) could be considered if there is demand.
