### PR TITLE
chore(metadata): bump policy version v1.1.0.

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -1,6 +1,6 @@
 rules:
   - apiGroups:
-      - ''
+      - ""
     apiVersions:
       - v1
     resources:
@@ -17,7 +17,7 @@ annotations:
   # kubewarden specific
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/volumes-psp
   io.kubewarden.policy.title: volumes-psp
-  io.kubewarden.policy.version: 1.0.3
+  io.kubewarden.policy.version: 1.1.0
   io.kubewarden.policy.description: Pod Security Policy that controls usage of volumes
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/kubewarden/volumes-psp-policy


### PR DESCRIPTION
## Description

Updates the policy version in the metadata.yml file to v1.1.0 in preperation to the next release making the new configuration to skip init container available to users.

